### PR TITLE
Update to go 1.24.1 fixed a few errors and lints in the upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/bgentry/go-netrc
+module github.com/cpuchip/go-netrc
 
-go 1.21.3
+go 1.24.1

--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -155,7 +155,6 @@ func (n *Netrc) insertMachineTokensBeforeDefault(m *Machine) {
 	}
 	// didn't find a default, just add the newtokens to the end
 	n.tokens = append(n.tokens, newtokens...)
-	return
 }
 
 func (n *Netrc) RemoveMachine(name string) {
@@ -349,7 +348,7 @@ func newToken(rawb []byte) (*token, error) {
 			t.kind = tkComment // this is a comment
 			return &t, nil
 		}
-		return &t, fmt.Errorf("keyword expected; got " + string(tkind))
+		return &t, fmt.Errorf("keyword expected; got %s", string(tkind))
 	}
 	return &t, nil
 }

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -8,17 +8,16 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 )
 
 var expectedMachines = []*Machine{
-	&Machine{Name: "mail.google.com", Login: "joe@gmail.com", Password: "somethingSecret", Account: "justagmail"},
-	&Machine{Name: "ray", Login: "demo", Password: "mypassword", Account: ""},
-	&Machine{Name: "weirdlogin", Login: "uname", Password: "pass#pass", Account: ""},
-	&Machine{Name: "", Login: "anonymous", Password: "joe@example.com", Account: ""},
+	{Name: "mail.google.com", Login: "joe@gmail.com", Password: "somethingSecret", Account: "justagmail"},
+	{Name: "ray", Login: "demo", Password: "mypassword", Account: ""},
+	{Name: "weirdlogin", Login: "uname", Password: "pass#pass", Account: ""},
+	{Name: "", Login: "anonymous", Password: "joe@example.com", Account: ""},
 }
 var expectedMacros = Macros{
 	"allput":  "put src/*",
@@ -185,7 +184,7 @@ func TestNetrcFindMachine(t *testing.T) {
 
 func TestMarshalText(t *testing.T) {
 	// load up expected netrc Marshal output
-	expected, err := ioutil.ReadAll(netrcReader("examples/good.netrc", t))
+	expected, err := io.ReadAll(netrcReader("examples/good.netrc", t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -559,7 +558,7 @@ func TestNewFile(t *testing.T) {
 }
 
 func netrcReader(filename string, t *testing.T) io.Reader {
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Updated to go 1.24.1

there were a few errors the cropped up because of the newer version of go. Fixed those and moved off of the deprecated ioutil mod to io and os mods.